### PR TITLE
書籍一覧画面のHTML/CSSの修正

### DIFF
--- a/src/main/resources/static/css/book/index.css
+++ b/src/main/resources/static/css/book/index.css
@@ -1,9 +1,8 @@
 .books_table {
- width: 100%;
  text-align: left;
  border-collapse: collapse;
  border-spacing: 0;
- border-radius:10px;
+ border-radius:10px; 
 }
 
 .books_table th{
@@ -12,7 +11,7 @@
   padding: 13px;
   border: solid 1px #B9B9B9;
   color: #545454;
-  font-size: 18px;
+  font-size: 15px;
 }
 
 .books_table td{
@@ -21,10 +20,14 @@
   background: #FFFFFF;
   border: solid 1px #B9B9B9;
   padding: 13px;
-  font-size: 20px;
+  font-size: 15px;
 }
 
 .books_table td:nth-child(1){
+  width: 60%;
+}
+
+.books_table td:nth-child(2){
   width: 40%;
 }
 
@@ -61,4 +64,24 @@
 
 .books_table td a{
   color: #0000EE;
+}
+
+.register-button{
+  background-color: #9affd3;
+  color: #333;
+  border: none;
+  float: right;
+  width: 120px;
+  height: 40px;
+  margin-right: 50px;
+}
+
+.title{
+  color: #888;
+
+}
+
+.table-wrapper{
+  width: 75%;
+  margin: 0 auto;
 }

--- a/src/main/resources/templates/book/index.html
+++ b/src/main/resources/templates/book/index.html
@@ -13,6 +13,25 @@
             <div class="inner_contens">
                 <div class="page_title">書籍一覧</div>
             </div>
+            <dr>
+                <a th:href="@{/book/add}"> <button class ="register-button">+書籍登録</button></a>
+            </dr>
+        <div class = "table-wrapper">
+            <h2 class ="title">書籍一覧</h2>
+            <table class ="books_table">
+                <thead>
+                    <tr>
+                        <th>書籍名</th>
+                        <th>ISBN</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr th:each="book : ${bookMstList}">
+                        <td th:text="${book.title}">書籍名</td>
+                        <td th:text="${book.isbn}">ISBN</td>
+                </tbody>
+            </table>
+        </div>  
         </div>
     </div>
     <div th:replace="~{common :: footer}"></div>


### PR DESCRIPTION
書籍一覧画のHTML/CSSを修正いたしました。
主に、以下の項目です。
・書籍登録画面へ遷移する緑色の「書籍登録」ボタンの追加
・書籍一覧表の追加
・表の中の「書籍名」と「ISBN」の比率を６：４に変更しました。
・表の文字の大きさの変更
・表の中央配置

書籍登録画面で新規に登録した値が、一覧画面で既存の表に追加されることも確認済みです。
ご確認よろしくお願いいたします。